### PR TITLE
Fixed a bug where scrollbars reappeared on mobile devices after vanishing

### DIFF
--- a/components/footer/index.js
+++ b/components/footer/index.js
@@ -12,7 +12,7 @@ const Footer = () => (
   <footer className="pt-16 pb-6 m-auto w-full max-w-[1260px]">
     <div className="text-sm">
       <div
-        className={["border-t  border-white border-opacity-10", sectionMarginX]
+        className={["border-t border-white border-opacity-10", sectionMarginX]
           .filter((x) => x)
           .join(" ")}
       />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -646,7 +646,7 @@ export default function Home() {
       </InnerSection>
 
       <Section className="!px-0">
-        <div className="w-full divide-y divide-accent rounded-lg lg:rounded-none overflow-hidden max-w-[720px] mx-auto">
+        <div className="w-full divide-y divide-accent rounded-lg lg:rounded-none max-w-[720px] mx-auto">
           <ExperienceWrapper title="Education">
             <Carousell
               direction="x"


### PR DESCRIPTION
Setting `overflow-hidden` on the parent of the Experience Wrapper had this weird side effect. If I one day have the time, I'll investigate this, might be a bug.